### PR TITLE
Add "external" to toplevel declarations

### DIFF
--- a/src/converter/TsClassifierToKt.kt
+++ b/src/converter/TsClassifierToKt.kt
@@ -2,6 +2,7 @@ package ts2kt
 
 import ts2kt.kotlin.ast.*
 import ts2kt.utils.assert
+import ts2kt.utils.reportUnsupportedNodeAndGetMessage
 import typescript.propertyName
 import typescriptServices.ts.*
 
@@ -104,6 +105,10 @@ abstract class TsClassifierToKt(
 
     override fun visitMethodDeclaration(node: MethodDeclaration) {
         val declarationName = node.propertyName!!
+        if(declarationName.kind == SyntaxKind.ComputedPropertyName){
+            reportUnsupportedNodeAndGetMessage(declarationName)
+            return
+        }
         val name = declarationName.unescapedText
         val isOverride = isOverride(node)
 

--- a/src/runner/runner.kt
+++ b/src/runner/runner.kt
@@ -38,7 +38,7 @@ fun translateToFile(srcPath: String, outPath: String) {
     val out =
             if (packageParts.isNotEmpty()) {
                 packageParts.joinToString("\n// ${"-".repeat(90)}\n") {
-                            it.stringify(packagePartPrefix = srcName)
+                            it.stringify(packagePartPrefix = srcName, topLevel = false)
                         }
             }
             else "// NO DECLARATIONS"
@@ -64,7 +64,7 @@ fun translateToDir(sources: List<String>, outDir: String, libraries: List<String
             val outFilePath = outDir + "/" + outFileName
 
             console.log("\t$outFilePath")
-            fs.writeFileSync(outFilePath, it.stringify())
+            fs.writeFileSync(outFilePath, it.stringify(null, topLevel = true))
         }
     }
 }


### PR DESCRIPTION
There was a fairly minor bug that prevented the commandline runner from adding the "external" qualifier to generated files.
See #36 
This also fixes an issue I encountered in the types for acorn, with the declaration:
`interface ITokenizer {
      [Symbol.iterator](): Iterator<Token>
    }`
It doesn't look like this project has the infrastructure to handle symbol-computed properties, so I added a check-and-skip. 
I think adding that functionality is issue #33