### PR TITLE
Don't specify external for extension functions and variables

### DIFF
--- a/src/main/kotlin/converter/KtPackagePartBuilder.kt
+++ b/src/main/kotlin/converter/KtPackagePartBuilder.kt
@@ -2,10 +2,7 @@ package converter
 
 import ts2kt.JS_MODULE
 import ts2kt.JS_QUALIFIER
-import ts2kt.kotlin.ast.KtAnnotation
-import ts2kt.kotlin.ast.KtArgument
-import ts2kt.kotlin.ast.KtMember
-import ts2kt.kotlin.ast.KtPackagePart
+import ts2kt.kotlin.ast.*
 import ts2kt.moduleAnnotation
 import typescriptServices.ts.Symbol
 
@@ -24,7 +21,7 @@ class KtPackagePartBuilder(
     fun build(): KtPackagePart {
         val allAnnotations = annotations.toMutableList()
 
-        if (members.none { it.annotations.any { it.name == JS_MODULE } }) {
+        if (members.none { it.annotations.any { it.name == JS_MODULE } } && members.all { it !is KtExtensionAware || it.extendsType == null }) {
             getEnclosingModule()?.let {
                 allAnnotations += moduleAnnotation(it)
             }

--- a/src/main/kotlin/ts2kt/TsInterfaceToKtExtensions.kt
+++ b/src/main/kotlin/ts2kt/TsInterfaceToKtExtensions.kt
@@ -2,6 +2,7 @@ package ts2kt
 
 import ts2kt.kotlin.ast.*
 import ts2kt.utils.assert
+import typescriptServices.ts.IndexSignatureDeclaration
 import typescriptServices.ts.MethodDeclaration
 import typescriptServices.ts.PropertyDeclaration
 import typescriptServices.ts.Symbol
@@ -50,6 +51,10 @@ class TsInterfaceToKtExtensions(
             list.addAll(this)
             list
         }
+    }
+
+    override fun visitIndexSignature(node: IndexSignatureDeclaration) {
+        super.translateGetterAndSetter(node, extendsType = cachedExtendsType)
     }
 
     override fun addVariable(symbol: Symbol?, name: String, type: KtType, extendsType: KtType?, typeParams: List<KtTypeParam>?, isVar: Boolean, needsNoImpl: Boolean, additionalAnnotations: List<KtAnnotation>, isOverride: Boolean) {

--- a/src/main/kotlin/ts2kt/kotlin/ast/ast.kt
+++ b/src/main/kotlin/ts2kt/kotlin/ast/ast.kt
@@ -90,6 +90,10 @@ interface KtAnnotated {
 
 interface KtMember : KtNode, KtNamed, KtAnnotated
 
+interface KtExtensionAware : KtMember {
+    val extendsType: KtHeritageType?
+}
+
 // TODO should be Named?
 data class KtArgument(val value: Any/* TODO Any ??? */, val name: KtName? = null) : AbstractKtNode() {
     override fun accept(visitor: KtVisitor) {
@@ -150,13 +154,13 @@ data class KtCallSignature(
 data class KtFunction(
         override var name: KtName,
         val callSignature: KtCallSignature,
-        val extendsType: KtHeritageType? = null,
+        override val extendsType: KtHeritageType? = null,
         override var annotations: List<KtAnnotation> = emptyList(),
         val needsNoImpl: Boolean = true,
         val isOverride: Boolean = false,
         val hasOpenModifier: Boolean = false,
         val isOperator: Boolean = false
-) : KtMember, AbstractKtNode() {
+) : KtMember, KtExtensionAware, AbstractKtNode() {
     override fun accept(visitor: KtVisitor) {
         visitor.visitFunction(this)
     }
@@ -165,7 +169,7 @@ data class KtFunction(
 data class KtVariable(
         override var name: KtName,
         var type: KtTypeAnnotation,
-        val extendsType: KtHeritageType? = null,
+        override val extendsType: KtHeritageType? = null,
         override var annotations: List<KtAnnotation>,
         val typeParams: List<KtTypeParam>?,
         var isVar: Boolean,
@@ -173,7 +177,7 @@ data class KtVariable(
         val isInInterface: Boolean,
         val isOverride: Boolean = false,
         val hasOpenModifier: Boolean
-) : KtMember, AbstractKtNode() {
+) : KtMember, KtExtensionAware, AbstractKtNode() {
     override fun accept(visitor: KtVisitor) {
         visitor.visitVariable(this)
     }

--- a/testData/extendExternalDeclarations/simple.d.kt
+++ b/testData/extendExternalDeclarations/simple.d.kt
@@ -1,12 +1,9 @@
 package simple
 
-external fun JQuery.foo(): Unit = definedExternally
-external var JQuery.bar: Any get() = definedExternally; set(value) = definedExternally
-@nativeGetter
-external operator fun JQueryStatic.get(prop: String): Number? = definedExternally
-@nativeSetter
-external operator fun JQueryStatic.set(prop: String, value: Number): Unit = definedExternally
-external var JQueryStatic.someField: String get() = definedExternally; set(value) = definedExternally
-external var JQueryStatic.optionalField: Any? get() = definedExternally; set(value) = definedExternally
-@nativeInvoke
-external operator fun JQueryStatic.invoke(resourceId: String, hash: Any? = definedExternally /* null */, callback: Function<*>? = definedExternally /* null */): Unit = definedExternally
+inline fun Event.foo(): Unit { this.asDynamic().foo() }
+inline var Event.bar: Any get() = this.asDynamic().bar; set(value) { this.asDynamic().bar = value }
+inline operator fun Event.get(prop: String): Number? { return this.asDynamic().get(prop) }
+inline operator fun Event.set(prop: String, value: Number): Unit { this.asDynamic().set(prop, value) }
+inline var Event.someField: String get() = this.asDynamic().someField; set(value) { this.asDynamic().someField = value }
+inline var Event.optionalField: Any? get() = this.asDynamic().optionalField; set(value) { this.asDynamic().optionalField = value }
+inline operator fun Event.invoke(resourceId: String, hash: Any? = null, callback: Function<*>? = null): Unit { this.asDynamic().invoke(resourceId, hash, callback) }

--- a/testData/extendExternalDeclarations/simple.d.ts
+++ b/testData/extendExternalDeclarations/simple.d.ts
@@ -1,14 +1,10 @@
 /// <reference path="../../testDefinitelyTyped/DefinitelyTyped/jquery/jquery.d.ts" />
 
-interface JQuery {
+interface Event {
     foo()
     bar
-}
-
-interface JQueryStatic {
     [prop: string]: number;
     someField: string;
     optionalField?: any;
     (resourceId:string, hash?:any, callback?:Function): void;
 }
-

--- a/testData/extendExternalDeclarations/withGenericParams.d.kt
+++ b/testData/extendExternalDeclarations/withGenericParams.d.kt
@@ -1,4 +1,3 @@
-@file:JsQualifier("Q")
 package withGenericParams.Q
 
 inline fun <T, B> Promise<T>.foo(b: B): T { return this.asDynamic().foo(b) }

--- a/testData/extendExternalDeclarations/withGenericParams.d.kt
+++ b/testData/extendExternalDeclarations/withGenericParams.d.kt
@@ -1,9 +1,9 @@
 @file:JsQualifier("Q")
 package withGenericParams.Q
 
-external fun <T, B> Promise<T>.foo(b: B): T = definedExternally
-external fun <T0, T, B> Promise<T0>.foo(a: Any, b: B): T = definedExternally
-external var <T> Promise<T>.bar: Array<T> get() = definedExternally; set(value) = definedExternally
+inline fun <T, B> Promise<T>.foo(b: B): T { return this.asDynamic().foo(b) }
+inline fun <T0, T, B> Promise<T0>.foo(a: Any, b: B): T { return this.asDynamic().foo(a, b) }
+inline var <T> Promise<T>.bar: Array<T> get() = this.asDynamic().bar; set(value) { this.asDynamic().bar = value }
 
 // ------------------------------------------------------------------------------------------
 @file:JsModule("ref-array")


### PR DESCRIPTION
This fixes #109.
Remove @file:JsQualifier if all functions and variables are extensions.